### PR TITLE
채널 사용

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
-	"sync"
 )
 
 func main() {
+	done := make(chan bool)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dump, err := httputil.DumpRequest(r, true)
 		if err != nil {
@@ -20,8 +20,6 @@ func main() {
 		fmt.Println(string(dump))
 	}))
 	fmt.Println(ts.URL)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	wg.Wait()
+	<-done
 	defer ts.Close()
 }


### PR DESCRIPTION
- `sync.WaitGroup` 을 이용해도 2 이상 값이 증가되지 않으므로 채널 여부로 종료 판별
- infinite loop 이어야 하므로 채널에 값을 셋팅하지 않음
